### PR TITLE
Add support for k8s 1.6

### DIFF
--- a/actions/entitytypes.go
+++ b/actions/entitytypes.go
@@ -3,7 +3,7 @@ package actions
 import (
 	libs "github.com/k8guard/k8guardlibs"
 	"github.com/k8guard/k8guardlibs/k8s"
-	"k8s.io/client-go/pkg/api/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type ActionableEntity interface {
@@ -23,7 +23,7 @@ func (a ActionPod) DoAction() {
 		panic(err)
 	}
 	libs.Log.Debug("Deleting Pod ", a.Name, " in namesapce ", a.Namespace)
-	err = clientset.CoreV1().Pods(a.Namespace).Delete(a.Name, &v1.DeleteOptions{})
+	err = clientset.CoreV1().Pods(a.Namespace).Delete(a.Name, &metav1.DeleteOptions{})
 	if err != nil {
 		libs.Log.Error(err)
 	}
@@ -35,14 +35,14 @@ func (a ActionDeployment) DoAction() {
 		panic(err)
 	}
 	libs.Log.Debug("Scaling Deployment ", a.Name, " in namesapce ", a.Namespace)
-	kd, err := clientset.Deployments(a.Namespace).Get(a.Name)
+	kd, err := clientset.AppsV1beta1().Deployments(a.Namespace).Get(a.Name, metav1.GetOptions{})
 	if err != nil {
 		libs.Log.Error(err)
 		return
 	}
 	replicas := int32(0)
 	kd.Spec.Replicas = &replicas
-	_, err = clientset.Deployments(a.Namespace).Update(kd)
+	_, err = clientset.AppsV1beta1().Deployments(a.Namespace).Update(kd)
 	if err != nil {
 		libs.Log.Error(err)
 	}
@@ -54,7 +54,7 @@ func (a ActionIngress) DoAction() {
 		panic(err)
 	}
 	libs.Log.Debug("Deleting Ingress ", a.Name, " in namesapce ", a.Namespace)
-	err = clientset.Ingresses(a.Namespace).Delete(a.Name, &v1.DeleteOptions{})
+	err = clientset.Ingresses(a.Namespace).Delete(a.Name, &metav1.DeleteOptions{})
 	if err != nil {
 		libs.Log.Error(err)
 	}
@@ -66,7 +66,7 @@ func (a ActionJob) DoAction() {
 		panic(err)
 	}
 	libs.Log.Debug("Deleting Job ", a.Name, " in namesapce ", a.Namespace)
-	err = clientset.BatchV2alpha1().Jobs(a.Namespace).Delete(a.Name, &v1.DeleteOptions{})
+	err = clientset.BatchV1().Jobs(a.Namespace).Delete(a.Name, &metav1.DeleteOptions{})
 	if err != nil {
 		libs.Log.Error(err)
 	}
@@ -79,7 +79,7 @@ func (a ActionCronJob) DoAction() {
 	}
 	libs.Log.Debug("Disabling CronJob ", a.Name, " in namesapce ", a.Namespace)
 
-	kcj, err := clientset.BatchV2alpha1().CronJobs(a.Namespace).Get(a.Name)
+	kcj, err := clientset.BatchV2alpha1().CronJobs(a.Namespace).Get(a.Name, metav1.GetOptions{})
 	if err != nil {
 		libs.Log.Error(err)
 		return

--- a/actions/notification.go
+++ b/actions/notification.go
@@ -14,6 +14,7 @@ import (
 	"github.com/k8guard/k8guardlibs/k8s"
 	"github.com/tbruyelle/hipchat-go/hipchat"
 	"gopkg.in/gomail.v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/pkg/api/v1"
 )
 
@@ -72,7 +73,7 @@ func NotifyOfViolation(actionMessage actionMessage) {
 		panic(err)
 	}
 
-	ns, err := clientset.CoreV1().Namespaces().Get(actionMessage.Namespace)
+	ns, err := clientset.CoreV1().Namespaces().Get(actionMessage.Namespace, metav1.GetOptions{})
 	if err != nil {
 		panic(err)
 	}

--- a/glide.lock
+++ b/glide.lock
@@ -1,31 +1,10 @@
-hash: 549b2d98c301c27606c35e74f3aced9686c6bf4d6eba274e65d763133ac19e1e
-updated: 2017-06-06T09:51:29.801723192-05:00
+hash: 3cc52a18341cfdde3821729149d5670ca3a1e6a7a80e48fec6433300c5b92c7e
+updated: 2017-07-14T13:24:13.482540308-05:00
 imports:
-- name: cloud.google.com/go
-  version: 3b1ae45394a234c385be014e9a488f2bb6eef821
-  subpackages:
-  - compute/metadata
-  - internal
-- name: github.com/blang/semver
-  version: 31b736133b98f26d5e078ec9eb591666edfd091f
 - name: github.com/caarlos0/env
   version: 9474f19b515f52326c7d197d2d097caa7fc7485e
   repo: https://github.com/caarlos0/env.git
   vcs: git
-- name: github.com/coreos/go-oidc
-  version: 5644a2f50e2d2d5ba0b474bc5bc55fea1925936d
-  subpackages:
-  - http
-  - jose
-  - key
-  - oauth2
-  - oidc
-- name: github.com/coreos/pkg
-  version: fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8
-  subpackages:
-  - health
-  - httputil
-  - timeutil
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
@@ -36,7 +15,7 @@ imports:
   - digest
   - reference
 - name: github.com/eapache/go-resiliency
-  version: b86b1ec0dd4209a588dc1285cdd471e73525c0b3
+  version: b1fe83b5b03f624450823b751b662259ffc6af70
   subpackages:
   - breaker
 - name: github.com/eapache/go-xerial-snappy
@@ -44,7 +23,7 @@ imports:
 - name: github.com/eapache/queue
   version: 44cc805cf13205b55f69e14bcb69867d1ae92f98
 - name: github.com/emicklei/go-restful
-  version: 89ef8af493ab468a45a42bb0d89a06fccdd2fb22
+  version: 09691a3b6378b740595c1002f40c34dd5f218a22
   subpackages:
   - log
   - swagger
@@ -71,10 +50,6 @@ imports:
   - sortkeys
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
-- name: github.com/golang/protobuf
-  version: 8616e8ee5e20a1704615e6c8d7afcdac06087a67
-  subpackages:
-  - proto
 - name: github.com/golang/snappy
   version: 553a641470496b2327abcac10b36396bd98e45c9
 - name: github.com/google/go-querystring
@@ -82,17 +57,17 @@ imports:
   subpackages:
   - query
 - name: github.com/google/gofuzz
-  version: bbcb9da2d746f8bdbd6a936686a0a6067ada0ec5
+  version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
 - name: github.com/hailocab/go-hostpool
   version: e80d13ce29ede4452c43dea11e79b9bc8a15b478
 - name: github.com/howeyc/gopass
   version: 3ca23474a7c7203e0a0a070fd33508f6efdb9b3d
 - name: github.com/imdario/mergo
   version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
-- name: github.com/jonboulle/clockwork
-  version: 72f9bd7c4e0c2a40055ab3d0f09654f730cce982
+- name: github.com/juju/ratelimit
+  version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/k8guard/k8guardlibs
-  version: cbb24b5a074f6f10649e72e27d968ece18a10594
+  version: 23932416d3db4a41a1558c9e934517ac4cad0d21
   repo: https://github.com/k8guard/k8guardlibs.git
   vcs: git
   subpackages:
@@ -101,19 +76,17 @@ imports:
   - messaging/kafka
   - violations
 - name: github.com/klauspost/crc32
-  version: 1bab8b35b6bb565f92cbc97939610af9369f942a
+  version: bab58d77464aa9cf4e84200c3276da0831fe0c03
 - name: github.com/mailru/easyjson
   version: d5b7844b561a7bc640052f1b935f7b800330d7e0
   subpackages:
   - buffer
   - jlexer
   - jwriter
-- name: github.com/pborman/uuid
-  version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/pierrec/lz4
   version: 5a3d2245f97fc249850e7802e3c01fad02a1c316
 - name: github.com/pierrec/xxHash
-  version: 5a004441f897722c627870a981d02b29924215fa
+  version: a0006b13c722f7f12368c00a3d3c2ae8a999a0c6
   subpackages:
   - xxHash32
 - name: github.com/PuerkitoBio/purell
@@ -127,35 +100,27 @@ imports:
 - name: github.com/sirupsen/logrus
   version: c078b1e43f58d563c74cebe63c85789e76ddb627
 - name: github.com/spf13/pflag
-  version: 5ccb023bc27df288a957c5e994cd44fd19619465
+  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/tbruyelle/hipchat-go
   version: fc3453606408cfa87015e65ecb3309f9d1678317
   subpackages:
   - hipchat
 - name: github.com/ugorji/go
-  version: f1f1a805ed361a0e078bb537e4ea78cd37dcf065
+  version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
   subpackages:
   - codec
 - name: golang.org/x/crypto
-  version: 1f22c0103821b9390939b6776727195525381532
+  version: d172538b2cfce0c13cee31e647d0367aa8cd2486
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
   version: e90d6d0afc4c315a0d87a568ae68577cc15149a0
   subpackages:
   - context
-  - context/ctxhttp
   - http2
   - http2/hpack
   - idna
   - lex/httplex
-- name: golang.org/x/oauth2
-  version: 3c3a985cb79f52a3190fbc056984415ca6763d01
-  subpackages:
-  - google
-  - internal
-  - jws
-  - jwt
 - name: golang.org/x/sys
   version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
   subpackages:
@@ -173,18 +138,6 @@ imports:
   - unicode/bidi
   - unicode/norm
   - width
-- name: google.golang.org/appengine
-  version: 4f7eeb5305a4ba1966344836ba4af9996b7b4e05
-  subpackages:
-  - internal
-  - internal/app_identity
-  - internal/base
-  - internal/datastore
-  - internal/log
-  - internal/modules
-  - internal/remote_api
-  - internal/urlfetch
-  - urlfetch
 - name: gopkg.in/alexcesaro/quotedprintable.v3
   version: 2caba252f4dc53eaf6b553000885530023f54623
 - name: gopkg.in/gomail.v2
@@ -193,54 +146,96 @@ imports:
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/yaml.v2
   version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
+- name: k8s.io/apimachinery
+  version: 85ace5365f33b16fc735c866a12e3c765b9700f2
+  subpackages:
+  - pkg/api/errors
+  - pkg/api/meta
+  - pkg/api/resource
+  - pkg/apimachinery
+  - pkg/apimachinery/announced
+  - pkg/apimachinery/registered
+  - pkg/apis/meta/v1
+  - pkg/apis/meta/v1/unstructured
+  - pkg/conversion
+  - pkg/conversion/queryparams
+  - pkg/fields
+  - pkg/labels
+  - pkg/openapi
+  - pkg/runtime
+  - pkg/runtime/schema
+  - pkg/runtime/serializer
+  - pkg/runtime/serializer/json
+  - pkg/runtime/serializer/protobuf
+  - pkg/runtime/serializer/recognizer
+  - pkg/runtime/serializer/streaming
+  - pkg/runtime/serializer/versioning
+  - pkg/selection
+  - pkg/types
+  - pkg/util/errors
+  - pkg/util/framer
+  - pkg/util/intstr
+  - pkg/util/json
+  - pkg/util/net
+  - pkg/util/rand
+  - pkg/util/runtime
+  - pkg/util/sets
+  - pkg/util/validation
+  - pkg/util/validation/field
+  - pkg/util/wait
+  - pkg/util/yaml
+  - pkg/version
+  - pkg/watch
+  - third_party/forked/golang/reflect
 - name: k8s.io/client-go
-  version: d81cb85237595f720d83eda492bae8f6162fc5c0
+  version: 21300e3e11c918b8e6a70fb7293b310683d6c046
   subpackages:
   - discovery
   - kubernetes
+  - kubernetes/scheme
   - kubernetes/typed/apps/v1beta1
+  - kubernetes/typed/authentication/v1
   - kubernetes/typed/authentication/v1beta1
+  - kubernetes/typed/authorization/v1
   - kubernetes/typed/authorization/v1beta1
   - kubernetes/typed/autoscaling/v1
+  - kubernetes/typed/autoscaling/v2alpha1
   - kubernetes/typed/batch/v1
   - kubernetes/typed/batch/v2alpha1
-  - kubernetes/typed/certificates/v1alpha1
+  - kubernetes/typed/certificates/v1beta1
   - kubernetes/typed/core/v1
   - kubernetes/typed/extensions/v1beta1
   - kubernetes/typed/policy/v1beta1
   - kubernetes/typed/rbac/v1alpha1
+  - kubernetes/typed/rbac/v1beta1
+  - kubernetes/typed/settings/v1alpha1
+  - kubernetes/typed/storage/v1
   - kubernetes/typed/storage/v1beta1
   - pkg/api
-  - pkg/api/errors
   - pkg/api/install
-  - pkg/api/meta
-  - pkg/api/meta/metatypes
-  - pkg/api/resource
-  - pkg/api/unversioned
   - pkg/api/v1
-  - pkg/api/validation/path
-  - pkg/apimachinery
-  - pkg/apimachinery/announced
-  - pkg/apimachinery/registered
   - pkg/apis/apps
   - pkg/apis/apps/install
   - pkg/apis/apps/v1beta1
   - pkg/apis/authentication
   - pkg/apis/authentication/install
+  - pkg/apis/authentication/v1
   - pkg/apis/authentication/v1beta1
   - pkg/apis/authorization
   - pkg/apis/authorization/install
+  - pkg/apis/authorization/v1
   - pkg/apis/authorization/v1beta1
   - pkg/apis/autoscaling
   - pkg/apis/autoscaling/install
   - pkg/apis/autoscaling/v1
+  - pkg/apis/autoscaling/v2alpha1
   - pkg/apis/batch
   - pkg/apis/batch/install
   - pkg/apis/batch/v1
   - pkg/apis/batch/v2alpha1
   - pkg/apis/certificates
   - pkg/apis/certificates/install
-  - pkg/apis/certificates/v1alpha1
+  - pkg/apis/certificates/v1beta1
   - pkg/apis/extensions
   - pkg/apis/extensions/install
   - pkg/apis/extensions/v1beta1
@@ -250,56 +245,19 @@ imports:
   - pkg/apis/rbac
   - pkg/apis/rbac/install
   - pkg/apis/rbac/v1alpha1
+  - pkg/apis/rbac/v1beta1
+  - pkg/apis/settings
+  - pkg/apis/settings/install
+  - pkg/apis/settings/v1alpha1
   - pkg/apis/storage
   - pkg/apis/storage/install
+  - pkg/apis/storage/v1
   - pkg/apis/storage/v1beta1
-  - pkg/auth/user
-  - pkg/conversion
-  - pkg/conversion/queryparams
-  - pkg/fields
-  - pkg/genericapiserver/openapi/common
-  - pkg/labels
-  - pkg/runtime
-  - pkg/runtime/serializer
-  - pkg/runtime/serializer/json
-  - pkg/runtime/serializer/protobuf
-  - pkg/runtime/serializer/recognizer
-  - pkg/runtime/serializer/streaming
-  - pkg/runtime/serializer/versioning
-  - pkg/selection
-  - pkg/third_party/forked/golang/reflect
-  - pkg/third_party/forked/golang/template
-  - pkg/types
   - pkg/util
-  - pkg/util/cert
-  - pkg/util/clock
-  - pkg/util/errors
-  - pkg/util/flowcontrol
-  - pkg/util/framer
-  - pkg/util/homedir
-  - pkg/util/integer
-  - pkg/util/intstr
-  - pkg/util/json
-  - pkg/util/jsonpath
-  - pkg/util/labels
-  - pkg/util/net
   - pkg/util/parsers
-  - pkg/util/rand
-  - pkg/util/ratelimit
-  - pkg/util/runtime
-  - pkg/util/sets
-  - pkg/util/uuid
-  - pkg/util/validation
-  - pkg/util/validation/field
-  - pkg/util/wait
-  - pkg/util/yaml
   - pkg/version
-  - pkg/watch
-  - pkg/watch/versioned
-  - plugin/pkg/client/auth
-  - plugin/pkg/client/auth/gcp
-  - plugin/pkg/client/auth/oidc
   - rest
+  - rest/watch
   - tools/auth
   - tools/clientcmd
   - tools/clientcmd/api
@@ -307,4 +265,9 @@ imports:
   - tools/clientcmd/api/v1
   - tools/metrics
   - transport
+  - util/cert
+  - util/clock
+  - util/flowcontrol
+  - util/homedir
+  - util/integer
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -13,8 +13,9 @@ import:
   version: 53e6ce116135b80d037921a7fdd5138cf32d7a8a
 
 - package: github.com/k8guard/k8guardlibs
-  version: cbb24b5a074f6f10649e72e27d968ece18a10594
   repo: https://github.com/k8guard/k8guardlibs.git
+  version: 23932416d3db4a41a1558c9e934517ac4cad0d21
   vcs: git
+
 
 - package: gopkg.in/gomail.v2


### PR DESCRIPTION
This is a breaking change, please refer to version compatibility matrix if you want to use it on k8s 1.5