### PR TITLE
Additional violations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 k8guard-action
 .env-creds
 .idea
+/.project

--- a/actions/actiontypes.go
+++ b/actions/actiontypes.go
@@ -91,6 +91,14 @@ type RequiredDaemonSetLabelAction struct {
 	violations.Violation
 }
 
+type RequiredResourceQuotaAction struct {
+	violations.Violation
+}
+
+type NoOwnerAction struct {
+	violations.Violation
+}
+
 // action for containers with extra capablities.
 func (a CapabilitiesAction) DoAction(entity ActionableEntity, vEntity libs.ViolatableEntity, lastActions map[string][]time.Time) []string {
 	return processAction(entity, vEntity, lastActions, "Extra Capabilities", a.Violation.Source, a.Type)
@@ -196,12 +204,25 @@ func (a RequiredDaemonSetLabelAction) DoAction(entity ActionableEntity, vEntity 
 	return processAction(entity, vEntity, lastActions, "Missing daemonset label", a.Violation.Source, a.Type)
 }
 
+// action for missing mandatory resourcequota
+func (a RequiredResourceQuotaAction) DoAction(entity ActionableEntity, vEntity libs.ViolatableEntity, lastActions map[string][]time.Time) []string {
+	return processAction(entity, vEntity, lastActions, "Missing required resourcequota", a.Violation.Source, a.Type)
+}
+
+// action for missing owner
+func (a NoOwnerAction) DoAction(entity ActionableEntity, vEntity libs.ViolatableEntity, lastActions map[string][]time.Time) []string {
+	return processAction(entity, vEntity, lastActions, "No owner", a.Violation.Source, a.Type)
+}
+
 func ConvertActionableEntityToViolatableEntity(entity ActionableEntity) (libs.ViolatableEntity, error) {
 
 	var vEntity libs.ViolatableEntity
 
 	switch t := entity.(type) {
 	case ActionDeployment:
+		vEntity = t.ViolatableEntity
+		break
+	case ActionNamespace:
 		vEntity = t.ViolatableEntity
 		break
 	case ActionDaemonSet:

--- a/actions/entitytypes.go
+++ b/actions/entitytypes.go
@@ -12,6 +12,7 @@ type ActionableEntity interface {
 
 // See http://stackoverflow.com/questions/28800672/how-to-add-new-methods-to-an-existing-type-in-go
 type ActionPod libs.Pod
+type ActionNamespace libs.Namespace
 type ActionDeployment libs.Deployment
 type ActionDaemonSet libs.DaemonSet
 type ActionIngress libs.Ingress
@@ -44,6 +45,18 @@ func (a ActionDeployment) DoAction() {
 	replicas := int32(0)
 	kd.Spec.Replicas = &replicas
 	_, err = clientset.AppsV1beta1().Deployments(a.Namespace).Update(kd)
+	if err != nil {
+		libs.Log.Error(err)
+	}
+}
+
+func (a ActionNamespace) DoAction() {
+	clientset, err := k8s.LoadClientset()
+	if err != nil {
+		panic(err)
+	}
+	libs.Log.Debug("Deleting Namespace ", a.Name)
+	err = clientset.Namespaces().Delete(a.Name, &metav1.DeleteOptions{})
 	if err != nil {
 		libs.Log.Error(err)
 	}

--- a/actions/entitytypes.go
+++ b/actions/entitytypes.go
@@ -13,6 +13,7 @@ type ActionableEntity interface {
 // See http://stackoverflow.com/questions/28800672/how-to-add-new-methods-to-an-existing-type-in-go
 type ActionPod libs.Pod
 type ActionDeployment libs.Deployment
+type ActionDaemonSet libs.DaemonSet
 type ActionIngress libs.Ingress
 type ActionJob libs.Job
 type ActionCronJob libs.CronJob
@@ -43,6 +44,18 @@ func (a ActionDeployment) DoAction() {
 	replicas := int32(0)
 	kd.Spec.Replicas = &replicas
 	_, err = clientset.AppsV1beta1().Deployments(a.Namespace).Update(kd)
+	if err != nil {
+		libs.Log.Error(err)
+	}
+}
+
+func (a ActionDaemonSet) DoAction() {
+	clientset, err := k8s.LoadClientset()
+	if err != nil {
+		panic(err)
+	}
+	libs.Log.Debug("Deleting DaemonSet ", a.Name, " in namesapce ", a.Namespace)
+	err = clientset.ExtensionsV1beta1().DaemonSets(a.Namespace).Delete(a.Name, &metav1.DeleteOptions{})
 	if err != nil {
 		libs.Log.Error(err)
 	}

--- a/actions/entitytypes.go
+++ b/actions/entitytypes.go
@@ -23,7 +23,7 @@ func (a ActionPod) DoAction() {
 	if err != nil {
 		panic(err)
 	}
-	libs.Log.Debug("Deleting Pod ", a.Name, " in namesapce ", a.Namespace)
+	libs.Log.Debug("Deleting Pod ", a.Name, " in namespace ", a.Namespace)
 	err = clientset.CoreV1().Pods(a.Namespace).Delete(a.Name, &metav1.DeleteOptions{})
 	if err != nil {
 		libs.Log.Error(err)
@@ -35,7 +35,7 @@ func (a ActionDeployment) DoAction() {
 	if err != nil {
 		panic(err)
 	}
-	libs.Log.Debug("Scaling Deployment ", a.Name, " in namesapce ", a.Namespace)
+	libs.Log.Debug("Scaling Deployment ", a.Name, " in namespace ", a.Namespace)
 	kd, err := clientset.AppsV1beta1().Deployments(a.Namespace).Get(a.Name, metav1.GetOptions{})
 	if err != nil {
 		libs.Log.Error(err)
@@ -54,7 +54,7 @@ func (a ActionDaemonSet) DoAction() {
 	if err != nil {
 		panic(err)
 	}
-	libs.Log.Debug("Deleting DaemonSet ", a.Name, " in namesapce ", a.Namespace)
+	libs.Log.Debug("Deleting DaemonSet ", a.Name, " in namespace ", a.Namespace)
 	err = clientset.ExtensionsV1beta1().DaemonSets(a.Namespace).Delete(a.Name, &metav1.DeleteOptions{})
 	if err != nil {
 		libs.Log.Error(err)
@@ -66,7 +66,7 @@ func (a ActionIngress) DoAction() {
 	if err != nil {
 		panic(err)
 	}
-	libs.Log.Debug("Deleting Ingress ", a.Name, " in namesapce ", a.Namespace)
+	libs.Log.Debug("Deleting Ingress ", a.Name, " in namespace ", a.Namespace)
 	err = clientset.Ingresses(a.Namespace).Delete(a.Name, &metav1.DeleteOptions{})
 	if err != nil {
 		libs.Log.Error(err)
@@ -78,7 +78,7 @@ func (a ActionJob) DoAction() {
 	if err != nil {
 		panic(err)
 	}
-	libs.Log.Debug("Deleting Job ", a.Name, " in namesapce ", a.Namespace)
+	libs.Log.Debug("Deleting Job ", a.Name, " in namespace ", a.Namespace)
 	err = clientset.BatchV1().Jobs(a.Namespace).Delete(a.Name, &metav1.DeleteOptions{})
 	if err != nil {
 		libs.Log.Error(err)
@@ -95,7 +95,7 @@ func (a ActionCronJob) DoAction() {
 	if err != nil {
 		panic(err)
 	}
-	libs.Log.Debug("Disabling CronJob ", a.Name, " in namesapce ", a.Namespace)
+	libs.Log.Debug("Disabling CronJob ", a.Name, " in namespace ", a.Namespace)
 
 	kcj, err := clientset.BatchV2alpha1().CronJobs(a.Namespace).Get(a.Name, metav1.GetOptions{})
 	if err != nil {

--- a/actions/entitytypes.go
+++ b/actions/entitytypes.go
@@ -73,6 +73,11 @@ func (a ActionJob) DoAction() {
 }
 
 func (a ActionCronJob) DoAction() {
+	if libs.Cfg.IncludeAlpha == false {
+		libs.Log.Debug("Ignoring CronJob action as alpha features are not enabled ")
+		return
+	}
+
 	clientset, err := k8s.LoadClientset()
 	if err != nil {
 		panic(err)

--- a/glide.yaml
+++ b/glide.yaml
@@ -14,7 +14,7 @@ import:
 
 - package: github.com/k8guard/k8guardlibs
   repo: https://github.com/k8guard/k8guardlibs.git
-  version: 23932416d3db4a41a1558c9e934517ac4cad0d21
+  version: 778e595d7eda2e64e5fc84ac3c091deecaef4743
   vcs: git
 
 

--- a/messaging/consume.go
+++ b/messaging/consume.go
@@ -191,39 +191,48 @@ func parseViolationMessage(msg *sarama.ConsumerMessage) {
 }
 
 func createAction(violation violations.Violation) actions.Action {
-	var action actions.Action
-
 	switch vType := violation.Type; vType {
 	case violations.SINGLE_REPLICA_TYPE:
-		action = actions.SingleReplicaAction{Violation: violation}
-		break
+		return actions.SingleReplicaAction{Violation: violation}
 	case violations.IMAGE_SIZE_TYPE:
-		action = actions.ImageSizeAction{Violation: violation}
-		break
+		return actions.ImageSizeAction{Violation: violation}
 	case violations.IMAGE_REPO_TYPE:
-		action = actions.ImageRepoAction{Violation: violation}
-		break
+		return actions.ImageRepoAction{Violation: violation}
 	case violations.INGRESS_HOST_INVALID_TYPE:
-		action = actions.IngressAction{Violation: violation}
-		break
+		return actions.IngressAction{Violation: violation}
 	case violations.CAPABILITIES_TYPE:
-		action = actions.CapabilitiesAction{Violation: violation}
-		break
+		return actions.CapabilitiesAction{Violation: violation}
 	case violations.PRIVILEGED_TYPE:
-		action = actions.PrivilegedAction{Violation: violation}
-		break
+		return actions.PrivilegedAction{Violation: violation}
 	case violations.HOST_VOLUMES_TYPE:
-		action = actions.HostVolumesAction{Violation: violation}
-		break
+		return actions.HostVolumesAction{Violation: violation}
+	case violations.REQUIRED_NAMESPACES_TYPE:
+		return actions.RequiredNamespaceAction{Violation: violation}
+	case violations.REQUIRED_NAMESPACE_ANNOTATIONS_TYPE:
+		return actions.RequiredNamespaceAnnotationAction{Violation: violation}
+	case violations.REQUIRED_NAMESPACE_LABELS_TYPE:
+		return actions.RequiredNamespaceLabelAction{Violation: violation}
+	case violations.REQUIRED_DEPLOYMENTS_TYPE:
+		return actions.RequiredDeploymentAction{Violation: violation}
+	case violations.REQUIRED_DEPLOYMENT_ANNOTATIONS_TYPE:
+		return actions.RequiredDeploymentAnnotationAction{Violation: violation}
+	case violations.REQUIRED_DEPLOYMENT_LABELS_TYPE:
+		return actions.RequiredDeploymentLabelAction{Violation: violation}
+	case violations.REQUIRED_PODS_TYPE:
+		return actions.RequiredPodAction{Violation: violation}
 	case violations.REQUIRED_POD_ANNOTATIONS_TYPE:
-		action = actions.RequiredPodAnnotationAction{Violation: violation}
-		break
+		return actions.RequiredPodAnnotationAction{Violation: violation}
+	case violations.REQUIRED_POD_LABELS_TYPE:
+		return actions.RequiredPodLabelAction{Violation: violation}
 	case violations.REQUIRED_DAEMONSETS_TYPE:
-		action = actions.RequiredDaemonSetAction{Violation: violation}
-		break
+		return actions.RequiredDaemonSetAction{Violation: violation}
+	case violations.REQUIRED_DAEMONSET_ANNOTATIONS_TYPE:
+		return actions.RequiredDaemonSetAnnotationAction{Violation: violation}
+	case violations.REQUIRED_DAEMONSET_LABELS_TYPE:
+		return actions.RequiredDaemonSetLabelAction{Violation: violation}
 	default:
 		libs.Log.Fatal("Unknown Violation Type ", vType)
 	}
 
-	return action
+	return nil
 }

--- a/messaging/consume.go
+++ b/messaging/consume.go
@@ -109,6 +109,16 @@ func parseViolationMessage(msg *sarama.ConsumerMessage) {
 		entityViolations = append(entityViolations, deployment.Violations...)
 
 		break
+	case string(kafka.DAEMONSET_MESSAGE):
+		libs.Log.Debug("Parsing DaemonSet Message")
+
+		daemonSet := actions.ActionDaemonSet{}
+		json.Unmarshal(dataBytes, &daemonSet)
+		actionableEntity = daemonSet
+
+		entityViolations = append(entityViolations, daemonSet.Violations...)
+
+		break
 	case string(kafka.INGRESS_MESSAGE):
 		libs.Log.Debug("Parsing Ingress Message")
 
@@ -207,6 +217,9 @@ func createAction(violation violations.Violation) actions.Action {
 		break
 	case violations.REQUIRED_POD_ANNOTATIONS_TYPE:
 		action = actions.RequiredPodAnnotationAction{Violation: violation}
+		break
+	case violations.REQUIRED_DAEMONSETS_TYPE:
+		action = actions.RequiredDaemonSetAction{Violation: violation}
 		break
 	default:
 		libs.Log.Fatal("Unknown Violation Type ", vType)

--- a/messaging/consume.go
+++ b/messaging/consume.go
@@ -99,6 +99,16 @@ func parseViolationMessage(msg *sarama.ConsumerMessage) {
 		entityViolations = append(entityViolations, pod.Violations...)
 
 		break
+	case string(kafka.NAMESPACE_MESSAGE):
+		libs.Log.Debug("Parsing Namespace Message")
+
+		namespace := actions.ActionNamespace{}
+		json.Unmarshal(dataBytes, &namespace)
+		actionableEntity = namespace
+
+		entityViolations = append(entityViolations, namespace.Violations...)
+
+		break
 	case string(kafka.DEPLOYMENT_MESSAGE):
 		libs.Log.Debug("Parsing Deployment Message")
 
@@ -230,6 +240,10 @@ func createAction(violation violations.Violation) actions.Action {
 		return actions.RequiredDaemonSetAnnotationAction{Violation: violation}
 	case violations.REQUIRED_DAEMONSET_LABELS_TYPE:
 		return actions.RequiredDaemonSetLabelAction{Violation: violation}
+	case violations.REQUIRED_RESOURCEQUOTA_TYPE:
+		return actions.RequiredResourceQuotaAction{Violation: violation}
+	case violations.NO_OWNER_ANNOTATION_TYPE:
+		return actions.NoOwnerAction{Violation: violation}
 	default:
 		libs.Log.Fatal("Unknown Violation Type ", vType)
 	}

--- a/messaging/consume.go
+++ b/messaging/consume.go
@@ -205,6 +205,9 @@ func createAction(violation violations.Violation) actions.Action {
 	case violations.HOST_VOLUMES_TYPE:
 		action = actions.HostVolumesAction{Violation: violation}
 		break
+	case violations.REQUIRED_POD_ANNOTATIONS_TYPE:
+		action = actions.RequiredPodAnnotationAction{Violation: violation}
+		break
 	default:
 		libs.Log.Fatal("Unknown Violation Type ", vType)
 	}


### PR DESCRIPTION
Added support for the following:
- Kubernetes Daemonsets
- Kubernetes ResourceQuotas
- Added missing no owner actions and namespace actions
- Checking for existence of mandatory namespaces, daemonsets and/or deployments
- Checking for existence of mandatory annotations on namespaces, daemonsets, deployments, and/or pods
- Checking for existence of mandatory labels on namespaces, daemonsets, deployments, and/or pods

Also, enhanced the rule configuration to allow setting per namespace and/or entity type, as well as exclusions.  Note that this is fully backwards compatible with the previous method (using the old method of providing a single value will still apply that globally).

Examples of new rule format:
- `K8GUARD_IGNORED_VIOLATIONS=mynamespace:*:*:PRIVILEGED`	- will ignore `PRIVILEGED` for all types within `mynamespace`. 
- `K8GUARD_IGNORED_VIOLATIONS=!mynamespace:daemonset:*:PRIVILEGED`	- will ignore `PRIVILEGED` for all daemonsets in any namespace but `mynamespace`.
- `K8GUARD_IGNORED_VIOLATIONS=*:daemonset:kube2iam:PRIVILEGED`	- will ignore `PRIVILEGED` only for daemonsets named `kube2iam` across all namespaces.

In addition, added the following new config values which use the `{namespace}:{entitytype}.{entityName}:{value}` format as described above:
- `K8GUARD_REQUIRED_ANNOTATIONS`
- `K8GUARD_REQUIRED_LABELS`
- `K8GUARD_REQUIRED_ENTITIES`

The only existing config variable that has been transitioned over to the `{namespace}:{entitytype}.{entityName}:{value}` format is `K8GUARD_IGNORED_VIOLATIONS`.
