### PR TITLE
Lighterweight dependencies

### DIFF
--- a/actions/actiontypes.go
+++ b/actions/actiontypes.go
@@ -91,6 +91,14 @@ type RequiredDaemonSetLabelAction struct {
 	violations.Violation
 }
 
+type RequiredResourceQuotaAction struct {
+	violations.Violation
+}
+
+type NoOwnerAction struct {
+	violations.Violation
+}
+
 // action for containers with extra capablities.
 func (a CapabilitiesAction) DoAction(entity ActionableEntity, vEntity libs.ViolatableEntity, lastActions map[string][]time.Time) []string {
 	return processAction(entity, vEntity, lastActions, "Extra Capabilities", a.Violation.Source, a.Type)
@@ -196,12 +204,25 @@ func (a RequiredDaemonSetLabelAction) DoAction(entity ActionableEntity, vEntity 
 	return processAction(entity, vEntity, lastActions, "Missing daemonset label", a.Violation.Source, a.Type)
 }
 
+// action for missing mandatory resourcequota
+func (a RequiredResourceQuotaAction) DoAction(entity ActionableEntity, vEntity libs.ViolatableEntity, lastActions map[string][]time.Time) []string {
+	return processAction(entity, vEntity, lastActions, "Missing required resourcequota", a.Violation.Source, a.Type)
+}
+
+// action for missing owner
+func (a NoOwnerAction) DoAction(entity ActionableEntity, vEntity libs.ViolatableEntity, lastActions map[string][]time.Time) []string {
+	return processAction(entity, vEntity, lastActions, "No owner", a.Violation.Source, a.Type)
+}
+
 func ConvertActionableEntityToViolatableEntity(entity ActionableEntity) (libs.ViolatableEntity, error) {
 
 	var vEntity libs.ViolatableEntity
 
 	switch t := entity.(type) {
 	case ActionDeployment:
+		vEntity = t.ViolatableEntity
+		break
+	case ActionNamespace:
 		vEntity = t.ViolatableEntity
 		break
 	case ActionDaemonSet:

--- a/actions/entitytypes.go
+++ b/actions/entitytypes.go
@@ -12,6 +12,7 @@ type ActionableEntity interface {
 
 // See http://stackoverflow.com/questions/28800672/how-to-add-new-methods-to-an-existing-type-in-go
 type ActionPod libs.Pod
+type ActionNamespace libs.Namespace
 type ActionDeployment libs.Deployment
 type ActionDaemonSet libs.DaemonSet
 type ActionIngress libs.Ingress
@@ -44,6 +45,18 @@ func (a ActionDeployment) DoAction() {
 	replicas := int32(0)
 	kd.Spec.Replicas = &replicas
 	_, err = clientset.AppsV1beta1().Deployments(a.Namespace).Update(kd)
+	if err != nil {
+		libs.Log.Error(err)
+	}
+}
+
+func (a ActionNamespace) DoAction() {
+	clientset, err := k8s.LoadClientset()
+	if err != nil {
+		panic(err)
+	}
+	libs.Log.Debug("Deleting Namespace ", a.Name)
+	err = clientset.Namespaces().Delete(a.Name, &metav1.DeleteOptions{})
 	if err != nil {
 		libs.Log.Error(err)
 	}

--- a/actions/entitytypes.go
+++ b/actions/entitytypes.go
@@ -13,6 +13,7 @@ type ActionableEntity interface {
 // See http://stackoverflow.com/questions/28800672/how-to-add-new-methods-to-an-existing-type-in-go
 type ActionPod libs.Pod
 type ActionDeployment libs.Deployment
+type ActionDaemonSet libs.DaemonSet
 type ActionIngress libs.Ingress
 type ActionJob libs.Job
 type ActionCronJob libs.CronJob
@@ -43,6 +44,18 @@ func (a ActionDeployment) DoAction() {
 	replicas := int32(0)
 	kd.Spec.Replicas = &replicas
 	_, err = clientset.AppsV1beta1().Deployments(a.Namespace).Update(kd)
+	if err != nil {
+		libs.Log.Error(err)
+	}
+}
+
+func (a ActionDaemonSet) DoAction() {
+	clientset, err := k8s.LoadClientset()
+	if err != nil {
+		panic(err)
+	}
+	libs.Log.Debug("Deleting DaemonSet ", a.Name, " in namesapce ", a.Namespace)
+	err = clientset.ExtensionsV1beta1().DaemonSets(a.Namespace).Delete(a.Name, &metav1.DeleteOptions{})
 	if err != nil {
 		libs.Log.Error(err)
 	}

--- a/actions/entitytypes.go
+++ b/actions/entitytypes.go
@@ -23,7 +23,7 @@ func (a ActionPod) DoAction() {
 	if err != nil {
 		panic(err)
 	}
-	libs.Log.Debug("Deleting Pod ", a.Name, " in namesapce ", a.Namespace)
+	libs.Log.Debug("Deleting Pod ", a.Name, " in namespace ", a.Namespace)
 	err = clientset.CoreV1().Pods(a.Namespace).Delete(a.Name, &metav1.DeleteOptions{})
 	if err != nil {
 		libs.Log.Error(err)
@@ -35,7 +35,7 @@ func (a ActionDeployment) DoAction() {
 	if err != nil {
 		panic(err)
 	}
-	libs.Log.Debug("Scaling Deployment ", a.Name, " in namesapce ", a.Namespace)
+	libs.Log.Debug("Scaling Deployment ", a.Name, " in namespace ", a.Namespace)
 	kd, err := clientset.AppsV1beta1().Deployments(a.Namespace).Get(a.Name, metav1.GetOptions{})
 	if err != nil {
 		libs.Log.Error(err)
@@ -54,7 +54,7 @@ func (a ActionDaemonSet) DoAction() {
 	if err != nil {
 		panic(err)
 	}
-	libs.Log.Debug("Deleting DaemonSet ", a.Name, " in namesapce ", a.Namespace)
+	libs.Log.Debug("Deleting DaemonSet ", a.Name, " in namespace ", a.Namespace)
 	err = clientset.ExtensionsV1beta1().DaemonSets(a.Namespace).Delete(a.Name, &metav1.DeleteOptions{})
 	if err != nil {
 		libs.Log.Error(err)
@@ -66,7 +66,7 @@ func (a ActionIngress) DoAction() {
 	if err != nil {
 		panic(err)
 	}
-	libs.Log.Debug("Deleting Ingress ", a.Name, " in namesapce ", a.Namespace)
+	libs.Log.Debug("Deleting Ingress ", a.Name, " in namespace ", a.Namespace)
 	err = clientset.Ingresses(a.Namespace).Delete(a.Name, &metav1.DeleteOptions{})
 	if err != nil {
 		libs.Log.Error(err)
@@ -78,7 +78,7 @@ func (a ActionJob) DoAction() {
 	if err != nil {
 		panic(err)
 	}
-	libs.Log.Debug("Deleting Job ", a.Name, " in namesapce ", a.Namespace)
+	libs.Log.Debug("Deleting Job ", a.Name, " in namespace ", a.Namespace)
 	err = clientset.BatchV1().Jobs(a.Namespace).Delete(a.Name, &metav1.DeleteOptions{})
 	if err != nil {
 		libs.Log.Error(err)
@@ -95,7 +95,7 @@ func (a ActionCronJob) DoAction() {
 	if err != nil {
 		panic(err)
 	}
-	libs.Log.Debug("Disabling CronJob ", a.Name, " in namesapce ", a.Namespace)
+	libs.Log.Debug("Disabling CronJob ", a.Name, " in namespace ", a.Namespace)
 
 	kcj, err := clientset.BatchV2alpha1().CronJobs(a.Namespace).Get(a.Name, metav1.GetOptions{})
 	if err != nil {

--- a/messaging/consume.go
+++ b/messaging/consume.go
@@ -1,14 +1,9 @@
 package messaging
 
 import (
-	"fmt"
-	"os"
-	"os/signal"
-	"syscall"
-
-	"github.com/Shopify/sarama"
 	libs "github.com/k8guard/k8guardlibs"
-	"github.com/k8guard/k8guardlibs/messaging/kafka"
+	"github.com/k8guard/k8guardlibs/messaging"
+	"github.com/k8guard/k8guardlibs/messaging/types"
 
 	"encoding/json"
 	"reflect"
@@ -22,50 +17,18 @@ import (
 
 func ConsumeMessages() {
 
-	signalChannel := make(chan os.Signal, 2)
-	signal.Notify(signalChannel, syscall.SIGTERM)
-
-	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, os.Interrupt)
-
-	topic := libs.Cfg.KafkaActionTopic
-
-	master, err := kafka.NewConsumer(kafka.ACTION_CLIENTID, libs.Cfg)
+	c, err := messaging.CreateMessageConsumer(
+		types.MessageBrokerType(libs.Cfg.MessageBroker), types.ACTION_CLIENTID, libs.Cfg)
 	if err != nil {
 		panic(err)
-
 	}
 
 	defer func() {
-		if err := master.Close(); err != nil {
-			panic(err)
-		}
+		c.Close()
 	}()
 
-	partitions, _ := master.Partitions(topic)
-
-	messages := make(chan *sarama.ConsumerMessage)
-	for _, partition := range partitions {
-
-		libs.Log.Info("Creating Consumer ", topic, " on partition ", partition)
-		consumer, err := master.ConsumePartition(topic, partition, sarama.OffsetNewest)
-		if err != nil {
-			panic(err)
-		}
-
-		go func(consumer sarama.PartitionConsumer) {
-			for {
-				select {
-				case err := <-consumer.Errors():
-					fmt.Println(err)
-				case msg := <-consumer.Messages():
-					messages <- msg
-				case <-signals:
-					libs.Log.Debug("Interrupt is detected")
-				}
-			}
-		}(consumer)
-	}
+	messages := make(chan []byte)
+	c.ConsumeMessages(messages)
 
 	libs.Log.Info("Waiting for messages")
 	for {
@@ -74,11 +37,11 @@ func ConsumeMessages() {
 	}
 }
 
-func parseViolationMessage(msg *sarama.ConsumerMessage) {
-	libs.Log.Info("Taking Action ...")
+func parseViolationMessage(msg []byte) {
+	libs.Log.Info("Processing violation message ...")
 
 	messageData := map[string]interface{}{}
-	err := json.Unmarshal(msg.Value, &messageData)
+	err := json.Unmarshal(msg, &messageData)
 	if err != nil {
 		libs.Log.Fatal(err)
 	}
@@ -89,7 +52,7 @@ func parseViolationMessage(msg *sarama.ConsumerMessage) {
 	var actionableEntity actions.ActionableEntity
 
 	switch messageData["kind"] {
-	case string(kafka.POD_MESSAGE):
+	case string(types.POD_MESSAGE):
 		libs.Log.Debug("Parsing Pod Message")
 
 		pod := actions.ActionPod{}
@@ -99,7 +62,7 @@ func parseViolationMessage(msg *sarama.ConsumerMessage) {
 		entityViolations = append(entityViolations, pod.Violations...)
 
 		break
-	case string(kafka.NAMESPACE_MESSAGE):
+	case string(types.NAMESPACE_MESSAGE):
 		libs.Log.Debug("Parsing Namespace Message")
 
 		namespace := actions.ActionNamespace{}
@@ -109,7 +72,7 @@ func parseViolationMessage(msg *sarama.ConsumerMessage) {
 		entityViolations = append(entityViolations, namespace.Violations...)
 
 		break
-	case string(kafka.DEPLOYMENT_MESSAGE):
+	case string(types.DEPLOYMENT_MESSAGE):
 		libs.Log.Debug("Parsing Deployment Message")
 
 		deployment := actions.ActionDeployment{}
@@ -119,7 +82,7 @@ func parseViolationMessage(msg *sarama.ConsumerMessage) {
 		entityViolations = append(entityViolations, deployment.Violations...)
 
 		break
-	case string(kafka.DAEMONSET_MESSAGE):
+	case string(types.DAEMONSET_MESSAGE):
 		libs.Log.Debug("Parsing DaemonSet Message")
 
 		daemonSet := actions.ActionDaemonSet{}
@@ -129,7 +92,7 @@ func parseViolationMessage(msg *sarama.ConsumerMessage) {
 		entityViolations = append(entityViolations, daemonSet.Violations...)
 
 		break
-	case string(kafka.INGRESS_MESSAGE):
+	case string(types.INGRESS_MESSAGE):
 		libs.Log.Debug("Parsing Ingress Message")
 
 		ingress := actions.ActionIngress{}
@@ -139,7 +102,7 @@ func parseViolationMessage(msg *sarama.ConsumerMessage) {
 		entityViolations = append(entityViolations, ingress.Violations...)
 
 		break
-	case string(kafka.JOB_MESSAGE):
+	case string(types.JOB_MESSAGE):
 		libs.Log.Debug("Parsing Job Message")
 
 		job := actions.ActionJob{}
@@ -149,7 +112,7 @@ func parseViolationMessage(msg *sarama.ConsumerMessage) {
 		entityViolations = append(entityViolations, job.Violations...)
 
 		break
-	case string(kafka.CRONJOB_MESSAGE):
+	case string(types.CRONJOB_MESSAGE):
 		libs.Log.Debug("Parsing CronJob Message")
 
 		cronjob := actions.ActionCronJob{}

--- a/messaging/consume.go
+++ b/messaging/consume.go
@@ -191,39 +191,48 @@ func parseViolationMessage(msg *sarama.ConsumerMessage) {
 }
 
 func createAction(violation violations.Violation) actions.Action {
-	var action actions.Action
-
 	switch vType := violation.Type; vType {
 	case violations.SINGLE_REPLICA_TYPE:
-		action = actions.SingleReplicaAction{Violation: violation}
-		break
+		return actions.SingleReplicaAction{Violation: violation}
 	case violations.IMAGE_SIZE_TYPE:
-		action = actions.ImageSizeAction{Violation: violation}
-		break
+		return actions.ImageSizeAction{Violation: violation}
 	case violations.IMAGE_REPO_TYPE:
-		action = actions.ImageRepoAction{Violation: violation}
-		break
+		return actions.ImageRepoAction{Violation: violation}
 	case violations.INGRESS_HOST_INVALID_TYPE:
-		action = actions.IngressAction{Violation: violation}
-		break
+		return actions.IngressAction{Violation: violation}
 	case violations.CAPABILITIES_TYPE:
-		action = actions.CapabilitiesAction{Violation: violation}
-		break
+		return actions.CapabilitiesAction{Violation: violation}
 	case violations.PRIVILEGED_TYPE:
-		action = actions.PrivilegedAction{Violation: violation}
-		break
+		return actions.PrivilegedAction{Violation: violation}
 	case violations.HOST_VOLUMES_TYPE:
-		action = actions.HostVolumesAction{Violation: violation}
-		break
+		return actions.HostVolumesAction{Violation: violation}
+	case violations.REQUIRED_NAMESPACES_TYPE:
+		return actions.RequiredNamespaceAction{Violation: violation}
+	case violations.REQUIRED_NAMESPACE_ANNOTATIONS_TYPE:
+		return actions.RequiredNamespaceAnnotationAction{Violation: violation}
+	case violations.REQUIRED_NAMESPACE_LABELS_TYPE:
+		return actions.RequiredNamespaceLabelAction{Violation: violation}
+	case violations.REQUIRED_DEPLOYMENTS_TYPE:
+		return actions.RequiredDeploymentAction{Violation: violation}
+	case violations.REQUIRED_DEPLOYMENT_ANNOTATIONS_TYPE:
+		return actions.RequiredDeploymentAnnotationAction{Violation: violation}
+	case violations.REQUIRED_DEPLOYMENT_LABELS_TYPE:
+		return actions.RequiredDeploymentLabelAction{Violation: violation}
+	case violations.REQUIRED_PODS_TYPE:
+		return actions.RequiredPodAction{Violation: violation}
 	case violations.REQUIRED_POD_ANNOTATIONS_TYPE:
-		action = actions.RequiredPodAnnotationAction{Violation: violation}
-		break
+		return actions.RequiredPodAnnotationAction{Violation: violation}
+	case violations.REQUIRED_POD_LABELS_TYPE:
+		return actions.RequiredPodLabelAction{Violation: violation}
 	case violations.REQUIRED_DAEMONSETS_TYPE:
-		action = actions.RequiredDaemonSetAction{Violation: violation}
-		break
+		return actions.RequiredDaemonSetAction{Violation: violation}
+	case violations.REQUIRED_DAEMONSET_ANNOTATIONS_TYPE:
+		return actions.RequiredDaemonSetAnnotationAction{Violation: violation}
+	case violations.REQUIRED_DAEMONSET_LABELS_TYPE:
+		return actions.RequiredDaemonSetLabelAction{Violation: violation}
 	default:
 		libs.Log.Fatal("Unknown Violation Type ", vType)
 	}
 
-	return action
+	return nil
 }

--- a/messaging/consume.go
+++ b/messaging/consume.go
@@ -109,6 +109,16 @@ func parseViolationMessage(msg *sarama.ConsumerMessage) {
 		entityViolations = append(entityViolations, deployment.Violations...)
 
 		break
+	case string(kafka.DAEMONSET_MESSAGE):
+		libs.Log.Debug("Parsing DaemonSet Message")
+
+		daemonSet := actions.ActionDaemonSet{}
+		json.Unmarshal(dataBytes, &daemonSet)
+		actionableEntity = daemonSet
+
+		entityViolations = append(entityViolations, daemonSet.Violations...)
+
+		break
 	case string(kafka.INGRESS_MESSAGE):
 		libs.Log.Debug("Parsing Ingress Message")
 
@@ -207,6 +217,9 @@ func createAction(violation violations.Violation) actions.Action {
 		break
 	case violations.REQUIRED_POD_ANNOTATIONS_TYPE:
 		action = actions.RequiredPodAnnotationAction{Violation: violation}
+		break
+	case violations.REQUIRED_DAEMONSETS_TYPE:
+		action = actions.RequiredDaemonSetAction{Violation: violation}
 		break
 	default:
 		libs.Log.Fatal("Unknown Violation Type ", vType)

--- a/messaging/consume.go
+++ b/messaging/consume.go
@@ -99,6 +99,16 @@ func parseViolationMessage(msg *sarama.ConsumerMessage) {
 		entityViolations = append(entityViolations, pod.Violations...)
 
 		break
+	case string(kafka.NAMESPACE_MESSAGE):
+		libs.Log.Debug("Parsing Namespace Message")
+
+		namespace := actions.ActionNamespace{}
+		json.Unmarshal(dataBytes, &namespace)
+		actionableEntity = namespace
+
+		entityViolations = append(entityViolations, namespace.Violations...)
+
+		break
 	case string(kafka.DEPLOYMENT_MESSAGE):
 		libs.Log.Debug("Parsing Deployment Message")
 
@@ -230,6 +240,10 @@ func createAction(violation violations.Violation) actions.Action {
 		return actions.RequiredDaemonSetAnnotationAction{Violation: violation}
 	case violations.REQUIRED_DAEMONSET_LABELS_TYPE:
 		return actions.RequiredDaemonSetLabelAction{Violation: violation}
+	case violations.REQUIRED_RESOURCEQUOTA_TYPE:
+		return actions.RequiredResourceQuotaAction{Violation: violation}
+	case violations.NO_OWNER_ANNOTATION_TYPE:
+		return actions.NoOwnerAction{Violation: violation}
 	default:
 		libs.Log.Fatal("Unknown Violation Type ", vType)
 	}

--- a/messaging/consume.go
+++ b/messaging/consume.go
@@ -205,6 +205,9 @@ func createAction(violation violations.Violation) actions.Action {
 	case violations.HOST_VOLUMES_TYPE:
 		action = actions.HostVolumesAction{Violation: violation}
 		break
+	case violations.REQUIRED_POD_ANNOTATIONS_TYPE:
+		action = actions.RequiredPodAnnotationAction{Violation: violation}
+		break
 	default:
 		libs.Log.Fatal("Unknown Violation Type ", vType)
 	}


### PR DESCRIPTION
Added support for an alternate lighter weight deployment of just Redis and Cassandra instead of Kafka, Zookeeper, Memcached and Cassandra.

Dependent upon PR https://github.com/k8guard/k8guard-action/pull/21.